### PR TITLE
Update install_windows_service.bat

### DIFF
--- a/src/electron/install_windows_service.bat
+++ b/src/electron/install_windows_service.bat
@@ -29,7 +29,7 @@ sc delete OutlineService
 
 :: Install and start the service, configuring it to restart on boot.
 :: NOTE: spaces after the arguments are necessary for a correct installation, do not remove!
-sc create OutlineService binpath= "%PWD%OutlineService.exe" displayname= "OutlineService" start= "auto"
+sc create OutlineService binpath= "\"%PWD%OutlineService.exe\"" displayname= "OutlineService" start= "auto"
 net start OutlineService
 
 :: This is for the client: sudo-prompt discards stdout/stderr if the script


### PR DESCRIPTION
added quotation marks to service path to avoid using the service as escalation tool for privileges as the service is running as SYSTEM user.